### PR TITLE
fix: address PR #117 review feedback

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -32,7 +32,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="WireMock.Net" Version="2.12.0" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="coverlet.msbuild" Version="10.0.1" />

--- a/src/Wemogy.Core.Tests/Wemogy.Core.Tests.csproj
+++ b/src/Wemogy.Core.Tests/Wemogy.Core.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,7 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="WireMock.Net" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Wemogy.Core/Helpers/RandomGenerator.cs
+++ b/src/Wemogy.Core/Helpers/RandomGenerator.cs
@@ -1,46 +1,52 @@
+using System;
 using System.Security.Cryptography;
 
 namespace Wemogy.Core.Helpers
 {
     public class RandomGenerator
     {
-        public static string GetUniqueToken(int length, string chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890-_")
+        public static string GenerateRandomToken(int length, string chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890-_")
         {
-            using (var crypto = RandomNumberGenerator.Create())
+            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(length, 0, nameof(length));
+            ArgumentException.ThrowIfNullOrWhiteSpace(chars, nameof(chars));
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(chars.Length, byte.MaxValue + 1, nameof(chars));
+
+            // Maximum random byte value usable without introducing modulo bias
+            int maxRandom = byte.MaxValue - ((byte.MaxValue + 1) % chars.Length);
+
+            Span<byte> data = length <= 256 ? stackalloc byte[length] : new byte[length];
+            RandomNumberGenerator.Fill(data);
+
+            Span<char> result = length <= 256 ? stackalloc char[length] : new char[length];
+            Span<byte> retryBuffer = stackalloc byte[1];
+
+            for (int i = 0; i < length; i++)
             {
-                byte[] data = new byte[length];
-
-                // Maximum random number that can be used without introducing a bias
-                int maxRandom = byte.MaxValue - ((byte.MaxValue + 1) % chars.Length);
-
-                crypto.GetBytes(data);
-
-                char[] result = new char[length];
-
-                for (int i = 0; i < length; i++)
+                byte value = data[i];
+                while (value > maxRandom)
                 {
-                    byte value = data[i];
-
-                    while (value > maxRandom)
-                    {
-                        // If chars.Length isn't a power of 2 then there is a bias if we simply use the modulus operator. The first characters of chars will be more probable than the last ones.
-                        // buffer used if we encounter an unusable random byte. We will regenerate it in this buffer
-                        var buffer = new byte[1];
-
-                        crypto.GetBytes(buffer);
-                        value = buffer[0];
-                    }
-
-                    result[i] = chars[value % chars.Length];
+                    // If chars.Length isn't a power of 2, using modulus directly would bias
+                    // the first characters of chars over the last ones. Rejection sampling
+                    // (regenerating out-of-range bytes) avoids that bias.
+                    RandomNumberGenerator.Fill(retryBuffer);
+                    value = retryBuffer[0];
                 }
 
-                return new string(result);
+                result[i] = chars[value % chars.Length];
             }
+
+            return new string(result);
+        }
+
+        [Obsolete("Use GenerateRandomToken instead. This method does not guarantee uniqueness.")]
+        public static string GetUniqueToken(int length, string chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890-_")
+        {
+            return GenerateRandomToken(length, chars);
         }
 
         public static string GenerateRandomPassword(int length)
         {
-            return GetUniqueToken(length);
+            return GenerateRandomToken(length);
         }
     }
 }


### PR DESCRIPTION
Addresses the review comments from #117.

## Changes

### `RandomGenerator` — safer token generation
- Renamed `GetUniqueToken` → `GenerateRandomToken` (it cannot guarantee uniqueness)
- Added argument range/null checks
- Uses `RandomNumberGenerator.Fill` with `Span`/`stackalloc` (no `using` clause)
- Kept rejection sampling to avoid modulo bias
- Kept `GetUniqueToken` as an `[Obsolete]` alias to avoid a hard breaking change for this published library

### xunit v2 → xunit.v3 migration
- Replaced `xunit` 2.9.3 with `xunit.v3` 3.2.2
- Added `<OutputType>Exe</OutputType>` (required by xunit v3 test projects)
- `xunit.runner.visualstudio` 3.1.5 already supports v3
- All **173 tests pass** on both net8.0 and net10.0

## Review comments not actioned (with reasoning)
- **`DictionaryExtensions.AddItem` double lookup** — already uses the single-lookup `TryGetValue` pattern; no change needed.
- **`Wemogy.Core.csproj` `TargetFrameworks` may be obsolete** — `Directory.Build.props` does not define `TargetFrameworks`, so the multi-target declaration is still required here.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>